### PR TITLE
Set version file URL property

### DIFF
--- a/GameData/ESLDBeacons/ESLD.version
+++ b/GameData/ESLDBeacons/ESLD.version
@@ -1,6 +1,6 @@
 ﻿{
      "NAME":"ESLD Jump Beacons",
-     "URL":"",
+     "URL":"https://github.com/DBooots/ESLDBeacons/raw/master/GameData/ESLDBeacons/ESLD.version",
      "DOWNLOAD":"https://github.com/DBooots/ESLDBeacons/releases",
      "GITHUB":{
          "USERNAME":"DBooots",


### PR DESCRIPTION
The "URL" property specifies an online copy of the version file that KSP-AVC and CKAN can check for updates. Now it's set to point to the copy on GitHub.

Hi @DBooots, tagging you here because GitHub unhelpfully doesn't notify people when pull requests are submitted.